### PR TITLE
Improve LRU Get speed

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -125,7 +125,7 @@ jobs:
   benchmark:
     name: benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 1
     strategy:
       matrix:
         go: [stable]
@@ -141,7 +141,7 @@ jobs:
           check-latest: true
           cache: true
       - name: run benchmarks
-        run: go test -run=- -benchmem -bench . github.com/wafer-bw/memcache/...
+        run: go test -run=- -benchmem -bench -benchtime=1x . github.com/wafer-bw/memcache/...
 
   gorelease:
     permissions:

--- a/cache_benchmark_test.go
+++ b/cache_benchmark_test.go
@@ -47,6 +47,25 @@ func BenchmarkCache_Get(b *testing.B) {
 	}
 }
 
+func BenchmarkCache_Get_parallel(b *testing.B) {
+	for policy, newCache := range policies {
+		cache, err := newCache(2)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		cache.Set(1, 1)
+
+		b.Run(fmt.Sprintf("%s policy parallel", policy), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, _ = cache.Get(1)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkCache_Has(b *testing.B) {
 	for policy, newCache := range policies {
 		for _, size := range sizes {

--- a/storelru.go
+++ b/storelru.go
@@ -56,29 +56,18 @@ func (s lruStore[K, V]) Set(key K, value Item[K, V]) {
 }
 
 func (s lruStore[K, V]) Get(key K) (Item[K, V], bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+	s.mu.RLock()
 	item, ok := s.items[key]
 	if !ok {
 		return Item[K, V]{}, false
 	}
+	s.mu.RUnlock()
 
+	s.mu.Lock()
 	s.list.MoveToFront(s.elements[key])
+	s.mu.Unlock()
 
 	return item, true
-
-	// TODO: compare against this:
-	// s.mu.RLock()
-	// item, ok := s.items[key]
-	// if !ok {
-	// 	return Item[K, V]{}, false
-	// }
-	// s.mu.RUnlock()
-	// s.mu.Lock()
-	// s.list.MoveToFront(s.elements[key])
-	// s.mu.Unlock()
-	// return item, true
 }
 
 func (s lruStore[K, V]) Items() (map[K]Item[K, V], unlockFunc) {


### PR DESCRIPTION
Before:
```
go test -benchmem -run=^$ -coverprofile=/tmp/vscode/go-code-cover -bench ^BenchmarkCache_Get_parallel$ github.com/wafer-bw/memcache -benchtime=100000000x
goos: linux
goarch: amd64
pkg: github.com/wafer-bw/memcache
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkCache_Get_parallel/noevict_policy_parallel-2           100000000               26.29 ns/op            0 B/op          0 allocs/op
BenchmarkCache_Get_parallel/lru_policy_parallel-2               100000000               42.20 ns/op            0 B/op          0 allocs/op
PASS
coverage: 30.9% of statements
ok      github.com/wafer-bw/memcache    6.856s
```

After
```
go test -benchmem -run=^$ -coverprofile=/tmp/vscode/go-code-cover -bench ^BenchmarkCache_Get_parallel$ github.com/wafer-bw/memcache -benchtime=100000000x
goos: linux
goarch: amd64
pkg: github.com/wafer-bw/memcache
cpu: AMD EPYC 7763 64-Core Processor                
BenchmarkCache_Get_parallel/noevict_policy_parallel-2           100000000               26.26 ns/op            0 B/op          0 allocs/op
BenchmarkCache_Get_parallel/lru_policy_parallel-2               100000000               37.76 ns/op            0 B/op          0 allocs/op
PASS
coverage: 32.0% of statements
ok      github.com/wafer-bw/memcache    6.409s
```